### PR TITLE
🔧 Fix environment variable access for Vite compatibility

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_BASE_URL: string
   readonly VITE_ENV: string
+  readonly VITE_SECRET_KEY: string
   // Add other env variables as needed
 }
 

--- a/src/components/contracts/ErrorBoundary.tsx
+++ b/src/components/contracts/ErrorBoundary.tsx
@@ -52,7 +52,7 @@ export class ContractsErrorBoundary extends Component<Props, State> {
                 An error occurred in the contracts module. Please try again or contact support if the problem persists.
               </p>
               
-              {process.env.NODE_ENV === 'development' && this.state.error && (
+              {import.meta.env.DEV && this.state.error && (
                 <details className="text-left bg-gray-100 p-4 rounded mt-4">
                   <summary className="cursor-pointer font-medium">Error Details</summary>
                   <pre className="mt-2 text-sm text-red-600 overflow-auto">

--- a/src/components/utils/ErrorBoundary.tsx
+++ b/src/components/utils/ErrorBoundary.tsx
@@ -50,7 +50,7 @@ class ErrorBoundary extends Component<Props, State> {
           >
             Refresh Page
           </button>
-          {process.env.NODE_ENV === 'development' && (
+          {import.meta.env.DEV && (
             <details className="mt-4 p-2 bg-gray-100 rounded text-sm">
               <summary className="cursor-pointer font-medium text-gray-700">
                 Error Details (Development)

--- a/src/configs/storageUtils.ts
+++ b/src/configs/storageUtils.ts
@@ -7,8 +7,12 @@ export class SecurityService  {
   private secretKey: string;
 
   private constructor() {
-    // Retrieve secret key from environment variables or use default
-    this.secretKey = process.env.VITE_SECRET_KEY || 'secretKey';
+    // Retrieve secret key from environment variables - fail fast if not configured
+    const envSecretKey = import.meta.env.VITE_SECRET_KEY;
+    if (!envSecretKey) {
+      throw new Error('VITE_SECRET_KEY environment variable is required for secure token storage');
+    }
+    this.secretKey = envSecretKey;
   }
 
   // Singleton access point


### PR DESCRIPTION
## Description

This PR addresses issues #11 and #14 by standardizing environment variable access to use `import.meta.env` instead of `process.env` for Vite compatibility.

## Changes Made

- **ErrorBoundary components**: Updated to use `import.meta.env.DEV` instead of `process.env.NODE_ENV`
- **SecurityService**: Fixed to use `import.meta.env.VITE_SECRET_KEY`
- **env.d.ts**: Added VITE_SECRET_KEY to TypeScript environment interface
- **Security**: Removed hardcoded fallback for better security

## Vite Compatibility

- All environment variable access now uses `import.meta.env`
- Proper TypeScript support for environment variables
- Consistent behavior across development and production

## Testing

- [ ] Verify ErrorBoundary components work correctly in dev/prod
- [ ] Test SecurityService with proper environment variables
- [ ] Ensure no runtime errors from environment variable access

Closes #11, #14