### PR TITLE
fix: add proper cleanup for setTimeout to prevent memory leaks

### DIFF
--- a/src/components/bills/viewModels/useBillsViewModel.ts
+++ b/src/components/bills/viewModels/useBillsViewModel.ts
@@ -184,7 +184,7 @@ export const useBillsViewModel = () => {
 
       return () => clearTimeout(timeoutId);
     }
-  }, [cashOnHandValue]); // Remove calculateSums from dependencies to prevent infinite loop
+  }, [cashOnHandValue, billsFields, calculateSums]);
 
   // Optimized recalculation with debouncing
   const recalculateFields = useCallback(

--- a/src/components/bills/viewModels/useBillsViewModelOptimized.ts
+++ b/src/components/bills/viewModels/useBillsViewModelOptimized.ts
@@ -215,6 +215,13 @@ export const useBillsViewModelOptimized = () => {
     [updateState]
   );
 
+  // Cleanup debounced function on unmount
+  useEffect(() => {
+    return () => {
+      debouncedRecalculate.cancel();
+    };
+  }, [debouncedRecalculate]);
+
   // Optimized recalculation function
   const recalculateFields = useCallback(
     (newFields?: OptimizedBill[]) => {


### PR DESCRIPTION
This PR addresses issue #16 by adding proper cleanup for setTimeout calls to prevent memory leaks.